### PR TITLE
Fix MoonBit warnings for 2026-05-09 promotion

### DIFF
--- a/src/undo_logs/pkg.generated.mbti
+++ b/src/undo_logs/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "BigOrangeQWQ/unification_table/undo_logs"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 pub fn[T] from_iter(Iter[Undo[T]], capacity? : Int) -> UndoLogs[T]
 
@@ -16,7 +20,7 @@ pub fn[T] setElem(Int, T) -> Undo[T]
 pub enum Undo[T] {
   NewElem(Int)
   SetElem(Int, T)
-}
+} derive(@debug.Debug)
 pub impl[T : Eq] Eq for Undo[T]
 pub impl[T : Show] Show for Undo[T]
 

--- a/src/undo_logs/undo_logs.mbt
+++ b/src/undo_logs/undo_logs.mbt
@@ -259,7 +259,7 @@ pub fn[T] UndoLogs::rollback_to(
   snapshot : Snapshot,
 ) -> Array[Undo[T]] {
   self.assert_valid_snapshot(snapshot)
-  let logs = self.action_since_snapshot(snapshot).to_array()
+  let logs = self.action_since_snapshot(snapshot).to_owned()
   for _ in 0..<logs.length() {
     let _ = self.pop()
   }

--- a/src/undo_logs/undo_logs.mbt
+++ b/src/undo_logs/undo_logs.mbt
@@ -3,7 +3,7 @@
 pub enum Undo[T] {
   NewElem(Int)
   SetElem(Int, T)
-}
+} derive(Debug)
 
 ///|
 pub type Snapshot = Int

--- a/src/undo_logs/undo_logs.mbti
+++ b/src/undo_logs/undo_logs.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "BigOrangeQWQ/unification_table/undo_logs"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 fn[T] from_iter(Iter[Undo[T]], capacity? : Int) -> UndoLogs[T]
 
@@ -16,7 +20,7 @@ fn[T] setElem(Int, T) -> Undo[T]
 pub enum Undo[T] {
   NewElem(Int)
   SetElem(Int, T)
-}
+} derive(@debug.Debug)
 impl[T : Eq] Eq for Undo[T]
 impl[T : Show] Show for Undo[T]
 
@@ -43,4 +47,3 @@ impl[T : Show] Show for UndoLogs[T]
 // Type aliases
 
 // Traits
-

--- a/src/undo_logs/undo_logs_test.mbt
+++ b/src/undo_logs/undo_logs_test.mbt
@@ -103,9 +103,9 @@ test "UndoLogs::start_snapshot" {
   let s1 = logs.start_snapshot()
   logs.push(newElem(0))
   logs.push(setElem(1, "test"))
-  inspect(
+  debug_inspect(
     logs.action_since_snapshot(s1),
-    content="[NewElem(0), SetElem(1, test)]",
+    content="<ArrayView: [NewElem(0), SetElem(1, \"test\")]>",
   )
 }
 
@@ -120,9 +120,9 @@ test "UndoLogs::rollback_to" {
   let s3 = logs.start_snapshot()
   logs.push(setElem(3, "another_rollback_test"))
   logs.push(newElem(4))
-  inspect(
+  debug_inspect(
     logs.rollback_to(s3),
-    content="[SetElem(3, another_rollback_test), NewElem(4)]",
+    content="[SetElem(3, \"another_rollback_test\"), NewElem(4)]",
   )
 }
 

--- a/src/unify_table/unify_table_test.mbt
+++ b/src/unify_table/unify_table_test.mbt
@@ -23,11 +23,11 @@ test "UnificationTable::push_var" {
 test "UnificationTable::get" {
   let table : UnificationTable[Int] = new(capacity=5)
   table.push(42)
-  inspect(
-    table.get(0),
-    content="Some(VarValue { value: 42, rank: 0, parent: VarIndex { index: 0 } })",
-  )
-  inspect(table.get(1), content="None")
+  let value = table.get(0).unwrap()
+  inspect(value.value, content="42")
+  inspect(value.rank, content="0")
+  inspect(value.parent.index, content="0")
+  assert_true(table.get(1) is None)
 }
 
 ///|
@@ -48,10 +48,10 @@ test "UnificationTable::value" {
   let table : UnificationTable[Int] = new(capacity=5)
   table.push(42)
   let index = new_index(0)
-  inspect(
-    table.value(index),
-    content="VarValue { value: 42, rank: 0, parent: VarIndex { index: 0 } }",
-  )
+  let value = table.value(index)
+  inspect(value.value, content="42")
+  inspect(value.rank, content="0")
+  inspect(value.parent.index, content="0")
 }
 
 ///|
@@ -87,10 +87,10 @@ test "UnificationTable::set" {
   table.push(42)
   let new_value = new_var_value(100, 0, new_index(0))
   table.set(new_index(0), new_value)
-  inspect(
-    table.get(0),
-    content="Some(VarValue { value: 100, rank: 0, parent: VarIndex { index: 0 } })",
-  )
+  let value = table.get(0).unwrap()
+  inspect(value.value, content="100")
+  inspect(value.rank, content="0")
+  inspect(value.parent.index, content="0")
 }
 
 ///|
@@ -98,10 +98,10 @@ test "UnificationTable::update" {
   let table : UnificationTable[Int] = new(capacity=5)
   table.push(42)
   table.update(new_index(0), fn(val) { val.root(val.rank, 100) })
-  inspect(
-    table.get(0),
-    content="Some(VarValue { value: 100, rank: 0, parent: VarIndex { index: 0 } })",
-  )
+  let value = table.get(0).unwrap()
+  inspect(value.value, content="100")
+  inspect(value.rank, content="0")
+  inspect(value.parent.index, content="0")
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Fix MoonBit warnings reported by the community-cakes dashboard for the 2026-05-09 promotion run.
- Update deprecated APIs and debug assertions as needed.

## Validation
- `moon check --target all`
- `moon fmt`
- Tests were run where feasible during the promotion pass.
