### PR TITLE
Fix MoonBit nightly warnings

### DIFF
--- a/src/snapshot_array/pkg.generated.mbti
+++ b/src/snapshot_array/pkg.generated.mbti
@@ -24,23 +24,25 @@ pub struct SnapshotArray[T] {
   values : Array[T]
 }
 pub fn[T] SnapshotArray::action_since_snapshot(Self[T], Snapshot) -> ArrayView[@undo_logs.Undo[T]]
+#alias(extend)
+pub fn[T] SnapshotArray::append_iter(Self[T], Iter[T]) -> Unit
 pub fn[T] SnapshotArray::commit(Self[T], Snapshot) -> Unit
 pub fn[T] SnapshotArray::commit_all(Self[T]) -> Unit
-pub fn[T] SnapshotArray::extend(Self[T], Iter[T]) -> Unit
 pub fn[T] SnapshotArray::get(Self[T], Int) -> T?
+#alias("_[_]")
+pub fn[T] SnapshotArray::get_at(Self[T], Int) -> T
 pub fn[T] SnapshotArray::in_snapshot(Self[T]) -> Bool
 pub fn[T] SnapshotArray::length(Self[T]) -> Int
-pub fn[T] SnapshotArray::op_get(Self[T], Int) -> T
-pub fn[T] SnapshotArray::op_set(Self[T], Int, T) -> Unit
 pub fn[T] SnapshotArray::push(Self[T], T) -> Unit
 pub fn[T] SnapshotArray::record(Self[T], @undo_logs.Undo[T]) -> Bool
 pub fn[T] SnapshotArray::reset(Self[T]) -> Unit
 pub fn[T] SnapshotArray::rollback_to(Self[T], Snapshot) -> Unit
 pub fn[T] SnapshotArray::set(Self[T], Int, T) -> Unit
 pub fn[T] SnapshotArray::set_all(Self[T], (T) -> T) -> Unit
+#alias("_[_]=_")
+pub fn[T] SnapshotArray::set_at(Self[T], Int, T) -> Unit
 pub fn[T] SnapshotArray::start_snapshot(Self[T]) -> Snapshot
 
 // Type aliases
 
 // Traits
-

--- a/src/snapshot_array/snapshot_array.mbt
+++ b/src/snapshot_array/snapshot_array.mbt
@@ -159,7 +159,8 @@ pub fn[T] SnapshotArray::reset(self : SnapshotArray[T]) -> Unit {
 /// inspect(arr.length(), content="3")
 /// inspect(arr.get(0).unwrap(), content="1")
 /// ```
-pub fn[T] SnapshotArray::extend(
+#alias(extend)
+pub fn[T] SnapshotArray::append_iter(
   self : SnapshotArray[T],
   iter : Iter[T],
 ) -> Unit {
@@ -389,7 +390,8 @@ pub fn[T] SnapshotArray::commit_all(self : SnapshotArray[T]) -> Unit {
 }
 
 ///|
-pub fn[T] SnapshotArray::op_get(self : SnapshotArray[T], index : Int) -> T {
+#alias("_[_]")
+pub fn[T] SnapshotArray::get_at(self : SnapshotArray[T], index : Int) -> T {
   if index < 0 || index >= self.values.length() {
     abort("Index out of bounds")
   }
@@ -397,7 +399,8 @@ pub fn[T] SnapshotArray::op_get(self : SnapshotArray[T], index : Int) -> T {
 }
 
 ///|
-pub fn[T] SnapshotArray::op_set(
+#alias("_[_]=_")
+pub fn[T] SnapshotArray::set_at(
   self : SnapshotArray[T],
   index : Int,
   value : T,

--- a/src/undo_logs/pkg.generated.mbti
+++ b/src/undo_logs/pkg.generated.mbti
@@ -21,6 +21,11 @@ pub enum Undo[T] {
   NewElem(Int)
   SetElem(Int, T)
 } derive(@debug.Debug)
+pub fn[T : Eq] Undo::equal(Self[T], Self[T]) -> Bool
+pub fn[T : Eq] Undo::not_equal(Self[T], Self[T]) -> Bool
+pub fn[T : Show] Undo::output(Self[T], &Logger) -> Unit
+pub fn[T : @debug.Debug] Undo::to_repr(Self[T]) -> @debug.Repr
+pub fn[T : Show] Undo::to_string(Self[T]) -> String
 pub impl[T : Eq] Eq for Undo[T]
 pub impl[T : Show] Show for Undo[T]
 
@@ -29,9 +34,10 @@ pub struct UndoLogs[T] {
   mut num_open_snapshots : Int
 }
 pub fn[T] UndoLogs::action_since_snapshot(Self[T], Int) -> ArrayView[Undo[T]]
+#alias(extend)
+pub fn[T] UndoLogs::append_iter(Self[T], Iter[Undo[T]]) -> Unit
 pub fn[T] UndoLogs::clear(Self[T]) -> Unit
 pub fn[T] UndoLogs::commit(Self[T], Int) -> Unit
-pub fn[T] UndoLogs::extend(Self[T], Iter[Undo[T]]) -> Unit
 pub fn[T] UndoLogs::has_changes(Self[T], Int) -> Bool
 pub fn[T] UndoLogs::in_snapshot(Self[T]) -> Bool
 pub fn[T] UndoLogs::iter(Self[T]) -> Iter[Undo[T]]
@@ -47,4 +53,3 @@ pub fn[T] UndoLogs::start_snapshot(Self[T]) -> Int
 pub type Snapshot = Int
 
 // Traits
-

--- a/src/undo_logs/undo_logs.mbt
+++ b/src/undo_logs/undo_logs.mbt
@@ -6,6 +6,9 @@ pub enum Undo[T] {
 } derive(Debug)
 
 ///|
+pub extend Undo with Debug::{to_repr}
+
+///|
 pub type Snapshot = Int
 
 ///|
@@ -136,7 +139,11 @@ pub fn[T] UndoLogs::clear(self : UndoLogs[T]) -> Unit {
 ///  inspect(logs.logs[0], content="NewElem(0)")
 ///  inspect(logs.logs[1], content="SetElem(1, test)")
 /// ```
-pub fn[T] UndoLogs::extend(self : UndoLogs[T], logs : Iter[Undo[T]]) -> Unit {
+#alias(extend)
+pub fn[T] UndoLogs::append_iter(
+  self : UndoLogs[T],
+  logs : Iter[Undo[T]],
+) -> Unit {
   logs.each(fn(log) { self.push(log) })
 }
 
@@ -305,7 +312,7 @@ pub fn[T] UndoLogs::iter(self : UndoLogs[T]) -> Iter[Undo[T]] {
 }
 
 ///|
-pub impl[T : Eq] Eq for Undo[T] with equal(self, other : Undo[T]) -> Bool {
+pub impl[T : Eq] Eq for Undo[T] with fn equal(self, other : Undo[T]) -> Bool {
   match (self, other) {
     (NewElem(index1), NewElem(index2)) => index1 == index2
     (SetElem(index1, value1), SetElem(index2, value2)) =>
@@ -315,7 +322,10 @@ pub impl[T : Eq] Eq for Undo[T] with equal(self, other : Undo[T]) -> Bool {
 }
 
 ///|
-pub impl[T : Show] Show for Undo[T] with to_string(self) {
+pub extend Undo with Eq::{not_equal, equal}
+
+///|
+pub impl[T : Show] Show for Undo[T] with fn to_string(self) {
   match self {
     NewElem(index) => "NewElem(" + index.to_string() + ")"
     SetElem(index, value) =>
@@ -324,6 +334,9 @@ pub impl[T : Show] Show for Undo[T] with to_string(self) {
 }
 
 ///|
-pub impl[T : Show] Show for Undo[T] with output(self, logger : &Logger) {
+pub extend Undo with Show::{to_string, output}
+
+///|
+pub impl[T : Show] Show for Undo[T] with fn output(self, logger : &Logger) {
   logger.write_string(self.to_string())
 }

--- a/src/unify_table/pkg.generated.mbti
+++ b/src/unify_table/pkg.generated.mbti
@@ -28,17 +28,21 @@ pub fn[T] UnificationTable::commit(Self[T], Snapshot) -> Unit
 pub fn[T] UnificationTable::find(Self[T], VarIndex) -> VarIndex
 pub fn[T] UnificationTable::find_root(Self[T], VarValue[T]) -> VarValue[T]
 pub fn[T] UnificationTable::get(Self[T], Int) -> VarValue[T]?
+#alias("_[_]")
+pub fn[T] UnificationTable::get_at(Self[T], Int) -> VarValue[T]
 pub fn[T] UnificationTable::in_snapshot(Self[T]) -> Bool
 pub fn[T] UnificationTable::index(Self[T], Int) -> VarIndex
-pub fn[T] UnificationTable::op_get(Self[T], Int) -> VarValue[T]
-pub fn[T] UnificationTable::op_set(Self[T], Int, VarValue[T]) -> Unit
+pub fn[T : Show] UnificationTable::output(Self[T], &Logger) -> Unit
 pub fn[T] UnificationTable::push(Self[T], T) -> Unit
 pub fn[T] UnificationTable::push_var(Self[T], VarValue[T]) -> Unit
 pub fn[T] UnificationTable::redirect_root(Self[T], Int, VarIndex, VarIndex, T) -> Unit
 pub fn[T] UnificationTable::reset(Self[T]) -> Unit
 pub fn[T] UnificationTable::rollback_to(Self[T], Snapshot) -> Unit
 pub fn[T] UnificationTable::set(Self[T], VarIndex, VarValue[T]) -> Unit
+#alias("_[_]=_")
+pub fn[T] UnificationTable::set_at(Self[T], Int, VarValue[T]) -> Unit
 pub fn[T] UnificationTable::start_snapshot(Self[T]) -> Snapshot
+pub fn[T : Show] UnificationTable::to_string(Self[T]) -> String
 pub fn[T] UnificationTable::unioned(Self[T], VarIndex, VarIndex) -> Bool
 pub fn[T] UnificationTable::unite(Self[T], VarIndex, VarIndex, T) -> VarIndex
 pub fn[T] UnificationTable::update(Self[T], VarIndex, (VarValue[T]) -> VarValue[T]) -> Unit
@@ -48,6 +52,8 @@ pub impl[T : Show] Show for UnificationTable[T]
 pub struct VarIndex {
   index : Int
 }
+pub fn VarIndex::output(Self, &Logger) -> Unit
+pub fn VarIndex::to_string(Self) -> String
 pub impl Show for VarIndex
 
 pub struct VarValue[T] {
@@ -55,13 +61,16 @@ pub struct VarValue[T] {
   mut rank : Int
   mut parent : VarIndex
 }
+pub fn[T : Eq] VarValue::equal(Self[T], Self[T]) -> Bool
 pub fn[T] VarValue::modify(Self[T], T) -> Unit
+pub fn[T : Eq] VarValue::not_equal(Self[T], Self[T]) -> Bool
+pub fn[T : Show] VarValue::output(Self[T], &Logger) -> Unit
 pub fn[T] VarValue::redirect(Self[T], VarIndex) -> Self[T]
 pub fn[T] VarValue::root(Self[T], Int, T) -> Self[T]
+pub fn[T : Show] VarValue::to_string(Self[T]) -> String
 pub impl[T : Eq] Eq for VarValue[T]
 pub impl[T : Show] Show for VarValue[T]
 
 // Type aliases
 
 // Traits
-

--- a/src/unify_table/unify_table.mbt
+++ b/src/unify_table/unify_table.mbt
@@ -124,12 +124,15 @@ pub fn new_snapshot(snapshot : @snapshot_array.Snapshot) -> Snapshot {
 }
 
 ///|
-pub impl[T : Eq] Eq for VarValue[T] with equal(self, other) {
+pub impl[T : Eq] Eq for VarValue[T] with fn equal(self, other) {
   self.value == other.value && self.parent == other.parent
 }
 
 ///|
-impl Eq for VarIndex with equal(self, other) {
+pub extend VarValue with Eq::{not_equal, equal}
+
+///|
+impl Eq for VarIndex with fn equal(self, other) {
   self.index == other.index
 }
 
@@ -627,7 +630,8 @@ pub fn[T] UnificationTable::commit(
 }
 
 ///|
-pub fn[T] UnificationTable::op_get(
+#alias("_[_]")
+pub fn[T] UnificationTable::get_at(
   self : UnificationTable[T],
   index : Int,
 ) -> VarValue[T] {
@@ -635,7 +639,8 @@ pub fn[T] UnificationTable::op_get(
 }
 
 ///|
-pub fn[T] UnificationTable::op_set(
+#alias("_[_]=_")
+pub fn[T] UnificationTable::set_at(
   self : UnificationTable[T],
   index : Int,
   value : VarValue[T],
@@ -644,7 +649,7 @@ pub fn[T] UnificationTable::op_set(
 }
 
 ///|
-pub impl[T : Show] Show for VarValue[T] with output(self, logger : &Logger) {
+pub impl[T : Show] Show for VarValue[T] with fn output(self, logger : &Logger) {
   logger
   ..write_string("VarValue { value: ")
   ..write_object(self.value)
@@ -656,7 +661,10 @@ pub impl[T : Show] Show for VarValue[T] with output(self, logger : &Logger) {
 }
 
 ///|
-pub impl Show for VarIndex with output(self, logger : &Logger) {
+pub extend VarValue with Show::{to_string, output}
+
+///|
+pub impl Show for VarIndex with fn output(self, logger : &Logger) {
   logger
   ..write_string("VarIndex { index: ")
   ..write_object(self.index)
@@ -664,7 +672,10 @@ pub impl Show for VarIndex with output(self, logger : &Logger) {
 }
 
 ///|
-pub impl[T : Show] Show for UnificationTable[T] with output(
+pub extend VarIndex with Show::{to_string, output}
+
+///|
+pub impl[T : Show] Show for UnificationTable[T] with fn output(
   self,
   logger : &Logger,
 ) {
@@ -675,3 +686,6 @@ pub impl[T : Show] Show for UnificationTable[T] with output(
     sep=", ",
   )
 }
+
+///|
+pub extend UnificationTable with Show::{to_string, output}


### PR DESCRIPTION
## Summary

- Fix 13 frozen nightly warnings: `0079` (7), `0027` (4), and `0035` (2).
- Add explicit Debug/Eq/Show extensions to retain existing dot-method APIs.
- Migrate deprecated indexing operators to named methods with compatibility aliases for `_[_]` and `_[_]=_`.
- Rename public reserved-keyword `extend` methods to `append_iter` while retaining `#alias(extend)` compatibility.
- Regenerate only the three affected tracked package interfaces.

Based on Community Cakes dashboard run #128.

## Validation

With `moon 0.1.20260815` / nightly `moonc v0.10.8` and `MOON_IGNORE_PREBUILD=1 MOON_WORK=off`:

- Four-target checks with `--deny-warn` passed
- Four-target tests with `--deny-warn` passed, 55/55 on each target
- `moon fmt`, targeted `moon info`, and diff checks passed

The compatibility aliases and generated interfaces were reviewed; no public API removal is intended.